### PR TITLE
Add Helm chart for deployment-inspector

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,84 @@
+name: Release Helm Chart
+
+on:
+  push:
+    tags:
+      - 'chart-v*.*.*'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  CHART_PATH: ./charts/deployment-inspector
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'latest'
+
+      - name: Extract version from tag
+        id: get_version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/chart-v* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/chart-}
+          else
+            VERSION="v0.1.0"
+          fi
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Chart version: ${VERSION}"
+
+      - name: Update Chart.yaml version
+        run: |
+          VERSION="${{ steps.get_version.outputs.VERSION }}"
+          VERSION_WITHOUT_V="${VERSION#v}"
+          sed -i "s/^version:.*/version: ${VERSION_WITHOUT_V}/" ${{ env.CHART_PATH }}/Chart.yaml
+          echo "Updated Chart.yaml with version: ${VERSION_WITHOUT_V}"
+          cat ${{ env.CHART_PATH }}/Chart.yaml
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Package Helm chart
+        run: |
+          helm package ${{ env.CHART_PATH }}
+          ls -la *.tgz
+
+      - name: Push Helm chart to OCI registry
+        run: |
+          CHART_VERSION="${{ steps.get_version.outputs.VERSION }}"
+          helm push deployment-inspector-*.tgz oci://${{ env.REGISTRY }}/takutakahashi/charts
+          echo "Chart pushed to: oci://${{ env.REGISTRY }}/takutakahashi/charts/deployment-inspector:${CHART_VERSION}"
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: deployment-inspector-*.tgz
+          generate_release_notes: true
+          body: |
+            ## Helm Chart Release ${{ steps.get_version.outputs.VERSION }}
+            
+            ### Installation
+            ```bash
+            helm install deployment-inspector oci://ghcr.io/takutakahashi/charts/deployment-inspector --version ${{ steps.get_version.outputs.VERSION }}
+            ```
+            
+            ### Upgrade
+            ```bash
+            helm upgrade deployment-inspector oci://ghcr.io/takutakahashi/charts/deployment-inspector --version ${{ steps.get_version.outputs.VERSION }}
+            ```
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/charts/deployment-inspector/.gitignore
+++ b/charts/deployment-inspector/.gitignore
@@ -1,0 +1,2 @@
+# Helm package files
+*.tgz

--- a/charts/deployment-inspector/Chart.yaml
+++ b/charts/deployment-inspector/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: deployment-inspector
+description: A Helm chart for deployment-inspector - tool to inspect Kubernetes deployments and run jobs on their nodes
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+home: https://github.com/takutakahashi/deployment-inspector
+sources:
+  - https://github.com/takutakahashi/deployment-inspector
+maintainers:
+  - name: takutakahashi
+    email: ""
+keywords:
+  - kubernetes
+  - deployment
+  - inspector
+  - cronjob
+icon: ""

--- a/charts/deployment-inspector/README.md
+++ b/charts/deployment-inspector/README.md
@@ -1,0 +1,50 @@
+# deployment-inspector
+
+A Helm chart for deployment-inspector - tool to inspect Kubernetes deployments and run jobs on their nodes
+
+## Installation
+
+```bash
+helm install deployment-inspector oci://ghcr.io/takutakahashi/charts/deployment-inspector --version v0.1.0
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the deployment-inspector chart and their default values.
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `cronjob.enabled` | Enable/disable the CronJob | `true` |
+| `cronjob.schedule` | Schedule for the CronJob | `"0 * * * *"` |
+| `cronjob.ttlSecondsAfterFinished` | TTL for automatic job cleanup | `3600` |
+| `deploymentInspector.command` | Command to run: "list" or "run-job" | `"list"` |
+| `deploymentInspector.deploymentName` | Target deployment name | `""` |
+| `deploymentInspector.namespace` | Target deployment namespace | `"default"` |
+| `deploymentInspector.job.namePrefix` | Job name prefix | `"inspector-job"` |
+| `deploymentInspector.job.namespace` | Job namespace | `""` |
+| `deploymentInspector.job.image` | Job container image | `"busybox"` |
+| `deploymentInspector.job.command` | Job command | `[]` |
+
+## Examples
+
+### List pods from a deployment every hour
+
+```yaml
+deploymentInspector:
+  command: "list"
+  deploymentName: "my-app"
+  namespace: "production"
+```
+
+### Run a job on nodes where deployment pods are running
+
+```yaml
+deploymentInspector:
+  command: "run-job"
+  deploymentName: "my-app"
+  namespace: "production"
+  job:
+    namePrefix: "node-inspector"
+    image: "alpine"
+    command: ["sh", "-c", "echo 'Running on node: $HOSTNAME'"]
+```

--- a/charts/deployment-inspector/templates/_helpers.tpl
+++ b/charts/deployment-inspector/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "deployment-inspector.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "deployment-inspector.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "deployment-inspector.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "deployment-inspector.labels" -}}
+helm.sh/chart: {{ include "deployment-inspector.chart" . }}
+{{ include "deployment-inspector.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "deployment-inspector.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "deployment-inspector.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "deployment-inspector.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "deployment-inspector.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/deployment-inspector/templates/cronjob.yaml
+++ b/charts/deployment-inspector/templates/cronjob.yaml
@@ -1,0 +1,103 @@
+{{- if .Values.cronjob.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "deployment-inspector.fullname" . }}
+  labels:
+    {{- include "deployment-inspector.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  schedule: {{ .Values.cronjob.schedule | quote }}
+  successfulJobsHistoryLimit: {{ .Values.cronjob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cronjob.failedJobsHistoryLimit }}
+  concurrencyPolicy: {{ .Values.cronjob.concurrencyPolicy }}
+  suspend: {{ .Values.cronjob.suspend }}
+  jobTemplate:
+    spec:
+      {{- if .Values.cronjob.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.cronjob.ttlSecondsAfterFinished }}
+      {{- end }}
+      backoffLimit: {{ .Values.cronjob.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "deployment-inspector.selectorLabels" . | nindent 12 }}
+            {{- with .Values.labels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.annotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        spec:
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          serviceAccountName: {{ include "deployment-inspector.serviceAccountName" . }}
+          {{- with .Values.podSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          restartPolicy: {{ .Values.cronjob.restartPolicy }}
+          containers:
+          - name: {{ .Chart.Name }}
+            {{- with .Values.securityContext }}
+            securityContext:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            {{- if eq .Values.deploymentInspector.command "list" }}
+            command:
+            - ./deployment-inspector
+            - list
+            - {{ required "deploymentInspector.deploymentName is required" .Values.deploymentInspector.deploymentName | quote }}
+            - "-n"
+            - {{ .Values.deploymentInspector.namespace | quote }}
+            {{- else if eq .Values.deploymentInspector.command "run-job" }}
+            command:
+            - ./deployment-inspector
+            - run-job
+            - {{ required "deploymentInspector.deploymentName is required" .Values.deploymentInspector.deploymentName | quote }}
+            - {{ .Values.deploymentInspector.job.namePrefix | quote }}
+            - "-n"
+            - {{ .Values.deploymentInspector.namespace | quote }}
+            {{- if .Values.deploymentInspector.job.namespace }}
+            - "-jn"
+            - {{ .Values.deploymentInspector.job.namespace | quote }}
+            {{- end }}
+            - "-i"
+            - {{ .Values.deploymentInspector.job.image | quote }}
+            {{- if .Values.deploymentInspector.job.command }}
+            - "-c"
+            - {{ join "," .Values.deploymentInspector.job.command | quote }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.env }}
+            env:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- with .Values.resources }}
+            resources:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/deployment-inspector/templates/rbac.yaml
+++ b/charts/deployment-inspector/templates/rbac.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.serviceAccount.create -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "deployment-inspector.fullname" . }}
+  labels:
+    {{- include "deployment-inspector.labels" . | nindent 4 }}
+rules:
+  # Read deployments
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list"]
+  # Read pods
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  # Create and manage jobs
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "deployment-inspector.fullname" . }}
+  labels:
+    {{- include "deployment-inspector.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "deployment-inspector.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "deployment-inspector.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/deployment-inspector/templates/serviceaccount.yaml
+++ b/charts/deployment-inspector/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "deployment-inspector.serviceAccountName" . }}
+  labels:
+    {{- include "deployment-inspector.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/deployment-inspector/values.yaml
+++ b/charts/deployment-inspector/values.yaml
@@ -1,0 +1,111 @@
+# Default values for deployment-inspector.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/takutakahashi/deployment-inspector
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# CronJob configuration
+cronjob:
+  # Enable/disable the CronJob
+  enabled: true
+  # Schedule for the CronJob (default: every hour)
+  schedule: "0 * * * *"
+  # Successful job history limit
+  successfulJobsHistoryLimit: 3
+  # Failed job history limit
+  failedJobsHistoryLimit: 1
+  # Concurrency policy: Allow, Forbid, Replace
+  concurrencyPolicy: Forbid
+  # Suspend the cronjob
+  suspend: false
+  # Time to live for the Job (in seconds) - job will be automatically deleted after this time
+  ttlSecondsAfterFinished: 3600
+  # Restart policy for the job
+  restartPolicy: OnFailure
+  # Backoff limit for the job
+  backoffLimit: 3
+
+# Configuration for deployment-inspector
+deploymentInspector:
+  # Command to run: "list" or "run-job"
+  command: "list"
+  # Target deployment name
+  deploymentName: ""
+  # Namespace where the target deployment is located
+  namespace: "default"
+  # For run-job command
+  job:
+    # Job name prefix (will be appended with timestamp)
+    namePrefix: "inspector-job"
+    # Namespace where jobs will be created
+    namespace: ""
+    # Container image for the job
+    image: "busybox"
+    # Command to run in the job
+    command: []
+    # Example: ["sh", "-c", "echo 'Hello from node'"]
+
+# Pod resource limits and requests
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# Node selector for pod assignment
+nodeSelector: {}
+
+# Tolerations for pod assignment
+tolerations: []
+
+# Affinity for pod assignment
+affinity: {}
+
+# Pod Security Context
+podSecurityContext: {}
+  # fsGroup: 2000
+
+# Container Security Context
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# Additional environment variables
+env: []
+  # - name: EXAMPLE_VAR
+  #   value: "example-value"
+
+# Additional labels
+labels: {}
+
+# Additional annotations
+annotations: {}

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,3 @@
 [tools]
 go = "latest"
+helm = "3"


### PR DESCRIPTION
## Summary
- Helm chart を作成し、deployment-inspector を CronJob として Kubernetes にデプロイ可能にしました
- OCI レジストリ (ghcr.io/takutakahashi/charts/deployment-inspector) への自動リリースを設定しました
- 全ての設定を values.yaml でカスタマイズ可能にしました

## Changes
- **Helm chart の作成**
  - `charts/deployment-inspector/` ディレクトリに Helm chart を作成
  - CronJob として動作し、スケジュールや TTL を設定可能
  - ServiceAccount と RBAC 設定を含む

- **GitHub Actions ワークフロー**
  - `chart-v*.*.*` タグで自動的に OCI レジストリにリリース
  - バージョンは自動的に Chart.yaml に反映

- **設定可能な主な機能**
  - CronJob のスケジュール（デフォルト: 毎時）
  - 対象デプロイメントの名前と名前空間
  - `list` または `run-job` コマンドの選択
  - Job 実行時のイメージやコマンドのカスタマイズ

## Test plan
- [ ] `helm lint` でチャートの検証（完了）
- [ ] GitHub Actions ワークフローの動作確認
- [ ] OCI レジストリへのプッシュ確認

## Usage
```bash
# インストール
helm install deployment-inspector oci://ghcr.io/takutakahashi/charts/deployment-inspector --version v0.1.0

# カスタム値でインストール
helm install deployment-inspector oci://ghcr.io/takutakahashi/charts/deployment-inspector \
  --version v0.1.0 \
  --set deploymentInspector.deploymentName=my-app \
  --set deploymentInspector.namespace=production
```

🤖 Generated with [Claude Code](https://claude.ai/code)