### PR TITLE
feat: Change Helm chart image tag default to use chart version

### DIFF
--- a/charts/deployment-inspector/Chart.yaml
+++ b/charts/deployment-inspector/Chart.yaml
@@ -3,7 +3,6 @@ name: deployment-inspector
 description: A Helm chart for deployment-inspector - tool to inspect Kubernetes deployments and run jobs on their nodes
 type: application
 version: 0.1.0
-appVersion: "1.0.0"
 home: https://github.com/takutakahashi/deployment-inspector
 sources:
   - https://github.com/takutakahashi/deployment-inspector

--- a/charts/deployment-inspector/templates/cronjob.yaml
+++ b/charts/deployment-inspector/templates/cronjob.yaml
@@ -52,7 +52,7 @@ spec:
             securityContext:
               {{- toYaml . | nindent 14 }}
             {{- end }}
-            image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             {{- if eq .Values.deploymentInspector.command "list" }}
             command:

--- a/charts/deployment-inspector/values.yaml
+++ b/charts/deployment-inspector/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/takutakahashi/deployment-inspector
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  # Overrides the image tag whose default is the chart version.
   tag: ""
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Changed the default image tag in Helm chart to use `.Chart.Version` instead of `.Chart.AppVersion`
- Removed `appVersion` field from Chart.yaml
- Updated comment in values.yaml to reflect the change

## Test plan
- [x] Tested helm template generation with default values
- [x] Tested helm template generation with custom image tag
- [x] Verified helm lint passes

🤖 Generated with [Claude Code](https://claude.ai/code)