### PR TITLE
Remove node name from job instance name to avoid pod name length limit

### DIFF
--- a/pkg/k8s/job.go
+++ b/pkg/k8s/job.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"strings"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -42,7 +41,7 @@ func (jm *JobManager) CreateJobOnNodes(jobName string, nodes []string, namespace
 	for _, node := range nodes {
 		rand.Seed(time.Now().UnixNano())
 		randomSuffix := fmt.Sprintf("%06d", rand.Intn(1000000))
-		jobInstanceName := fmt.Sprintf("%s-%s-%s", jobName, strings.ReplaceAll(node, ".", "-"), randomSuffix)
+		jobInstanceName := fmt.Sprintf("%s-%s", jobName, randomSuffix)
 		
 		ttlSecondsAfterFinished := int32(300) // 5 minutes after completion
 		job := &batchv1.Job{


### PR DESCRIPTION
## Summary
- Removed node name from job instance naming to prevent pod names from exceeding Kubernetes' 63 character limit
- Job names now only include the job name and a 6-digit random suffix

## Background
When node names are long, the generated pod names can exceed the 63 character limit imposed by Kubernetes, causing job creation to fail. By removing the node name from the job instance name, we ensure that pod names stay within the acceptable length.

## Changes
- Modified `CreateJobOnNodes` in `pkg/k8s/job.go` to generate job names without the node name
- Job instance names now follow the pattern: `{jobName}-{6-digit-random}`
- Removed unused `strings` import

## Test plan
- [x] Run existing unit tests
- [x] All tests pass without modification

🤖 Generated with [Claude Code](https://claude.ai/code)