### PR TITLE
Remove GitHub Release creation from Helm chart workflow

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -62,23 +62,3 @@ jobs:
           helm push deployment-inspector-*.tgz oci://${{ env.REGISTRY }}/takutakahashi/charts
           echo "Chart pushed to: oci://${{ env.REGISTRY }}/takutakahashi/charts/deployment-inspector:${CHART_VERSION}"
 
-      - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
-        with:
-          files: deployment-inspector-*.tgz
-          generate_release_notes: true
-          body: |
-            ## Helm Chart Release ${{ steps.get_version.outputs.VERSION }}
-            
-            ### Installation
-            ```bash
-            helm install deployment-inspector oci://ghcr.io/takutakahashi/charts/deployment-inspector --version ${{ steps.get_version.outputs.VERSION }}
-            ```
-            
-            ### Upgrade
-            ```bash
-            helm upgrade deployment-inspector oci://ghcr.io/takutakahashi/charts/deployment-inspector --version ${{ steps.get_version.outputs.VERSION }}
-            ```
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Removed GitHub Release creation step from the Helm chart release workflow
- Helm charts are now only published to the OCI registry (ghcr.io)

## Background
Since Helm charts are published directly to the OCI registry, creating a GitHub Release with the chart tarball is redundant. Users can install the chart directly from the OCI registry without needing to download release artifacts.

## Changes
- Removed the `Create GitHub Release` step from `.github/workflows/helm-release.yml`
- The workflow now only builds and pushes the Helm chart to the OCI registry

## Test plan
The workflow will continue to:
- [x] Trigger on version tags (v*.*.*)
- [x] Build the Helm chart package
- [x] Push to OCI registry at `oci://ghcr.io/takutakahashi/charts/deployment-inspector`

Users can still install the chart using:
```bash
helm install deployment-inspector oci://ghcr.io/takutakahashi/charts/deployment-inspector --version <VERSION>
```

🤖 Generated with [Claude Code](https://claude.ai/code)