### PR TITLE
Add toleration support for job creation

### DIFF
--- a/cmd/deployment-inspector/main_test.go
+++ b/cmd/deployment-inspector/main_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestParseTolerations(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    []corev1.Toleration
+		expectError bool
+	}{
+		{
+			name:  "simple key=value:effect format",
+			input: "role=myrole:NoSchedule",
+			expected: []corev1.Toleration{
+				{
+					Key:      "role",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "myrole",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:  "simple key:effect format (no value)",
+			input: "role:NoSchedule",
+			expected: []corev1.Toleration{
+				{
+					Key:      "role",
+					Operator: corev1.TolerationOpExists,
+					Value:    "",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:  "multiple tolerations",
+			input: "role=myrole:NoSchedule,env=test:PreferNoSchedule",
+			expected: []corev1.Toleration{
+				{
+					Key:      "role",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "myrole",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "env",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "test",
+					Effect:   corev1.TaintEffectPreferNoSchedule,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:  "case insensitive effects",
+			input: "role=myrole:noschedule",
+			expected: []corev1.Toleration{
+				{
+					Key:      "role",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "myrole",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:  "NoExecute effect",
+			input: "role=myrole:NoExecute",
+			expected: []corev1.Toleration{
+				{
+					Key:      "role",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "myrole",
+					Effect:   corev1.TaintEffectNoExecute,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:  "JSON format",
+			input: `[{"key":"role","operator":"Equal","value":"myrole","effect":"NoSchedule"}]`,
+			expected: []corev1.Toleration{
+				{
+					Key:      "role",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "myrole",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:        "invalid format - no colon",
+			input:       "role=myrole",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "invalid effect",
+			input:       "role=myrole:InvalidEffect",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "invalid JSON",
+			input:       `[{"invalid": json}]`,
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []corev1.Toleration{},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseTolerations(tt.input)
+			
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("Expected %d tolerations, got %d", len(tt.expected), len(result))
+				return
+			}
+
+			for i, expected := range tt.expected {
+				actual := result[i]
+				if actual.Key != expected.Key {
+					t.Errorf("Expected key %s, got %s", expected.Key, actual.Key)
+				}
+				if actual.Operator != expected.Operator {
+					t.Errorf("Expected operator %s, got %s", expected.Operator, actual.Operator)
+				}
+				if actual.Value != expected.Value {
+					t.Errorf("Expected value %s, got %s", expected.Value, actual.Value)
+				}
+				if actual.Effect != expected.Effect {
+					t.Errorf("Expected effect %s, got %s", expected.Effect, actual.Effect)
+				}
+			}
+		})
+	}
+}

--- a/pkg/k8s/job.go
+++ b/pkg/k8s/job.go
@@ -14,7 +14,7 @@ import (
 
 // JobManagerInterface defines operations for job management
 type JobManagerInterface interface {
-	CreateJobOnNodes(jobName string, nodes []string, namespace, image string, command []string) ([]string, error)
+	CreateJobOnNodes(jobName string, nodes []string, namespace, image string, command []string, tolerations []corev1.Toleration) ([]string, error)
 }
 
 // JobManager manages job-related operations
@@ -30,7 +30,7 @@ func NewJobManager(clientset kubernetes.Interface) JobManagerInterface {
 }
 
 // CreateJobOnNodes creates jobs on specified nodes
-func (jm *JobManager) CreateJobOnNodes(jobName string, nodes []string, namespace, image string, command []string) ([]string, error) {
+func (jm *JobManager) CreateJobOnNodes(jobName string, nodes []string, namespace, image string, command []string, tolerations []corev1.Toleration) ([]string, error) {
 	if len(command) == 0 {
 		command = []string{"echo", "Job running on node"}
 	}
@@ -62,6 +62,7 @@ func (jm *JobManager) CreateJobOnNodes(jobName string, nodes []string, namespace
 						NodeSelector: map[string]string{
 							"kubernetes.io/hostname": node,
 						},
+						Tolerations: tolerations,
 						Containers: []corev1.Container{
 							{
 								Name:    "job-container",


### PR DESCRIPTION
## Summary
- Add `--tolerations`/`-t` flag to `run-job` command for specifying pod tolerations in JSON format
- Update JobManager interface to accept tolerations parameter
- Implement toleration support in job pod specification
- Add comprehensive test cases for toleration functionality

## Changes
- **cmd/deployment-inspector/main.go**: Add tolerations flag and JSON parsing
- **pkg/k8s/job.go**: Update JobManager interface and implement toleration support in pod spec
- **pkg/k8s/job_test.go**: Add test case for tolerations functionality

## Usage
```bash
deployment-inspector run-job my-deployment my-job \
  --tolerations '[{"key":"key1","operator":"Equal","value":"value1","effect":"NoSchedule"}]'
```

## Test plan
- [x] Build succeeds without errors
- [x] All existing tests pass
- [x] New toleration test case passes
- [x] CLI help shows new toleration flag
- [x] JSON parsing works correctly for tolerations

🤖 Generated with [Claude Code](https://claude.ai/code)