### PR TITLE
Add Helm chart toleration support for job creation

### DIFF
--- a/charts/deployment-inspector/templates/cronjob.yaml
+++ b/charts/deployment-inspector/templates/cronjob.yaml
@@ -82,7 +82,11 @@ spec:
             {{- end }}
             {{- if .Values.deploymentInspector.job.tolerations }}
             - "--tolerations"
+            {{- if kindIs "string" .Values.deploymentInspector.job.tolerations }}
+            - {{ .Values.deploymentInspector.job.tolerations | quote }}
+            {{- else }}
             - {{ .Values.deploymentInspector.job.tolerations | toJson | quote }}
+            {{- end }}
             {{- end }}
             {{- end }}
             {{- with .Values.env }}

--- a/charts/deployment-inspector/templates/cronjob.yaml
+++ b/charts/deployment-inspector/templates/cronjob.yaml
@@ -80,6 +80,10 @@ spec:
             - "--command"
             - {{ join "," .Values.deploymentInspector.job.command | quote }}
             {{- end }}
+            {{- if .Values.deploymentInspector.job.tolerations }}
+            - "--tolerations"
+            - {{ .Values.deploymentInspector.job.tolerations | toJson | quote }}
+            {{- end }}
             {{- end }}
             {{- with .Values.env }}
             env:

--- a/charts/deployment-inspector/values.yaml
+++ b/charts/deployment-inspector/values.yaml
@@ -65,12 +65,15 @@ deploymentInspector:
     # Example: ["sh", "-c", "echo 'Hello from node'"]
     # Tolerations for the job pods (will be passed to the CLI)
     tolerations: []
-    # Example:
+    # Examples:
+    # YAML format:
     # tolerations:
     #   - key: "node.kubernetes.io/not-ready"
     #     operator: "Exists"
     #     effect: "NoExecute"
     #     tolerationSeconds: 300
+    # Short string format:
+    # tolerations: "role=worker:NoSchedule,env=test:PreferNoSchedule"
 
 # Pod resource limits and requests
 resources: {}

--- a/charts/deployment-inspector/values.yaml
+++ b/charts/deployment-inspector/values.yaml
@@ -63,6 +63,14 @@ deploymentInspector:
     # Command to run in the job
     command: []
     # Example: ["sh", "-c", "echo 'Hello from node'"]
+    # Tolerations for the job pods (will be passed to the CLI)
+    tolerations: []
+    # Example:
+    # tolerations:
+    #   - key: "node.kubernetes.io/not-ready"
+    #     operator: "Exists"
+    #     effect: "NoExecute"
+    #     tolerationSeconds: 300
 
 # Pod resource limits and requests
 resources: {}


### PR DESCRIPTION
## Summary
- Add toleration configuration support to Helm chart for job creation
- Support both YAML list format and short string format for tolerations
- Enable users to specify tolerations via values.yaml that are passed to deployment-inspector CLI

## Changes
- **values.yaml**: Add `deploymentInspector.job.tolerations` configuration with comprehensive documentation
- **cronjob.yaml**: Add conditional logic to pass tolerations to CLI via `--tolerations` flag
- Support both formats:
  - YAML format: `tolerations: [{key: "role", value: "worker", effect: "NoSchedule"}]`
  - Short format: `tolerations: "role=worker:NoSchedule,env=test:PreferNoSchedule"`

## Test plan
- [x] Helm template rendering with toleration configuration
- [x] Helm template rendering without tolerations (backward compatibility)
- [x] Helm lint validation
- [x] Test both YAML and string format tolerations
- [x] Verify CLI argument generation

## Usage Examples

### YAML format (recommended):
```yaml
deploymentInspector:
  command: "run-job"
  deploymentName: "my-deployment"
  job:
    tolerations:
      - key: "node.kubernetes.io/not-ready"
        operator: "Exists"
        effect: "NoExecute"
        tolerationSeconds: 300
```

### Short string format:
```yaml
deploymentInspector:
  job:
    tolerations: "role=worker:NoSchedule,env=test:PreferNoSchedule"
```

### Command line:
```bash
helm install my-release ./charts/deployment-inspector \
  --set deploymentInspector.command=run-job \
  --set deploymentInspector.deploymentName=my-deployment \
  --set 'deploymentInspector.job.tolerations=role=worker:NoSchedule'
```

## Backward Compatibility
- Fully backward compatible - existing configurations continue to work unchanged
- When no tolerations are specified, no `--tolerations` flag is added to the command

🤖 Generated with [Claude Code](https://claude.ai/code)